### PR TITLE
improve preview alignment

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.CountDownTimer
 import android.provider.MediaStore
 import android.view.*
 import android.widget.LinearLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.core.view.*
 import androidx.transition.*
@@ -325,7 +326,9 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
             initInPhotoMode = isInPhotoMode,
         )
 
-        mFocusCircleView = FocusCircleView(this)
+        mFocusCircleView = FocusCircleView(this).apply {
+            id = View.generateViewId()
+        }
         view_holder.addView(mFocusCircleView)
 
         setupPreviewImage(true)
@@ -823,6 +826,19 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
         val states = arrayOf(intArrayOf(-android.R.attr.state_checked), intArrayOf(android.R.attr.state_checked))
         val iconColors = intArrayOf(ContextCompat.getColor(this, R.color.md_grey_white), primaryColor)
         button.iconTint = ColorStateList(states, iconColors)
+    }
+
+    override fun adjustPreviewView(requiresCentering: Boolean) {
+        val constraintSet = ConstraintSet()
+        constraintSet.clone(view_holder)
+        if (requiresCentering) {
+            constraintSet.connect(preview_view.id, ConstraintSet.TOP, top_options.id, ConstraintSet.BOTTOM)
+            constraintSet.connect(preview_view.id, ConstraintSet.BOTTOM, camera_mode_tab.id, ConstraintSet.TOP)
+        } else {
+            constraintSet.connect(preview_view.id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+            constraintSet.connect(preview_view.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+        }
+        constraintSet.applyTo(view_holder)
     }
 
     override fun mediaSaved(path: String) {

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -161,6 +161,8 @@ class CameraXPreview(
             MySize(selectedQuality.width, selectedQuality.height)
         }
 
+        listener.adjustPreviewView(resolution.requiresCentering())
+
         val isFullSize = resolution.isFullScreen
         previewView.scaleType = if (isFullSize) ScaleType.FILL_CENTER else ScaleType.FIT_CENTER
         val rotation = previewView.display.rotation

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreviewListener.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreviewListener.kt
@@ -30,6 +30,6 @@ interface CameraXPreviewListener {
         isFrontCamera: Boolean,
         onSelect: (index: Int, changed: Boolean) -> Unit,
     )
-
     fun showFlashOptions(photoCapture: Boolean)
+    fun adjustPreviewView(requiresCentering: Boolean)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
@@ -17,6 +17,10 @@ data class MySize(val width: Int, val height: Int, val isFullScreen: Boolean = f
 
     val megaPixels: String = String.format("%.1f", (width * height.toFloat()) / ONE_MEGA_PIXEL)
 
+    fun requiresCentering(): Boolean {
+        return !isFullScreen && (isFourToThree() || isThreeToTwo() || isSquare())
+    }
+
     fun isSixteenToNine() = ratio == 16 / 9f
 
     private fun isFiveToThree() = ratio == 5 / 3f

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,9 @@
     <androidx.camera.view.PreviewView
         android:id="@+id/preview_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <View
         android:id="@+id/shutter_animation"


### PR DESCRIPTION
- improve preview alignment
- center the `PreviewView` between the top action icons and the bottom mode switcher view for `4:3`, `3:2` (video mode - `SD`) and `1:1` resolutions, when not full screen